### PR TITLE
Remove fields from help discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/help2.yml
+++ b/.github/DISCUSSION_TEMPLATE/help2.yml
@@ -1,9 +1,3 @@
-name: "🆘 Help / Support"
-description: "Ask for help, debugging or troubleshooting"
-title: "[Help]: Add a title"
-labels:
-  - "help wanted"
-
 body:
   - type: input
     id: title


### PR DESCRIPTION
Removed help discussion template fields for name, description, and labels.